### PR TITLE
グリッド背景付きのメインビジュアルを実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: 220 83% 47%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Noto_Sans_JP, Outfit } from "next/font/google";
 import type React from "react";
 import "./globals.css";
-import { Header } from "@/components/Header";
 
 const outfit = Outfit({
   subsets: ["latin"],
@@ -66,7 +65,6 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={`${outfit.variable} ${notoSansJP.variable} font-sans`}>
-        <Header />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,9 @@
-import { SeekingSponsorsSection } from "@/components/SeekingSponsorsSection";
+import { EventCountdownBanner } from "@/components/EventCountdownBanner";
 
 export default function Home() {
   return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <h1 className="text-4xl font-bold">TSKaigi 2025</h1>
-      <SeekingSponsorsSection />
-    </div>
+    <main>
+      <EventCountdownBanner />
+    </main>
   );
 }

--- a/src/components/EventCountdownBanner/GridBackground/index.tsx
+++ b/src/components/EventCountdownBanner/GridBackground/index.tsx
@@ -1,0 +1,26 @@
+export function GridBackground() {
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute inset-[-50%] w-[200%] h-[200%] opacity-15 bg-[length:42px_42px] lg:bg-[length:55px_55px]"
+      style={{
+        backgroundImage: `
+            linear-gradient(hsl(var(--primary)) 2px, transparent 2px),
+            linear-gradient(90deg, hsl(var(--primary)) 2px, transparent 2px)
+          `,
+        mask: `radial-gradient(
+            ellipse 40% 50% at center,
+            black 0%,
+            black 20%,
+            transparent 50%
+          )`,
+        WebkitMask: `radial-gradient(
+            ellipse 40% 50% at center,
+            black 0%,
+            black 20%,
+            transparent 50%
+          )`,
+      }}
+    />
+  );
+}

--- a/src/components/EventCountdownBanner/index.tsx
+++ b/src/components/EventCountdownBanner/index.tsx
@@ -1,0 +1,9 @@
+import { GridBackground } from "@/components/EventCountdownBanner/GridBackground";
+
+export function EventCountdownBanner() {
+  return (
+    <div className="w-full min-h-screen relative flex flex-col items-center justify-center gap-10 text-center">
+      <GridBackground />
+    </div>
+  );
+}

--- a/src/components/EventCountdownBanner/index.tsx
+++ b/src/components/EventCountdownBanner/index.tsx
@@ -4,6 +4,21 @@ export function EventCountdownBanner() {
   return (
     <div className="w-full min-h-screen relative flex flex-col items-center justify-center gap-10 text-center">
       <GridBackground />
+
+      <img
+        src="/logo.svg"
+        className="absolute top-6 left-6 w-40 lg:w-64 lg:top-10 lg:left-10"
+        alt="logo"
+      />
+
+      <div className="text-2xl font-semibold space-y-1">
+        <time dateTime="2025-05-23">5/23, 5/24</time>
+        <p>ベルサール神田</p>
+      </div>
+
+      <h1 className="text-5xl font-bold text-primary w-96 lg:w-full">
+        TSKaigi 2025 Coming Soon
+      </h1>
     </div>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-export function Header() {
-  return (
-    <header className="sticky top-0 w-full p-4 lg:p-8 bg-background">
-      <img src="/logo.svg" className="w-40 lg:w-64" alt="logo" />
-    </header>
-  );
-}


### PR DESCRIPTION
## 対応したこと

- グリッド背景の実装
- カウントダウン以外のUIを実装（ロゴ、日時と場所、見出し）
- #144BDB をグローバルのプライマリーカラーに設定

## やってないこと

- グリッドの透過の度合いを画面サイズごとに調整（他のUI実装後に調整します）
- カウントダウンコンポーネントの修正

## 関連資料
https://www.figma.com/design/JKCppXvTVKtFGRa6hNYXBz/Web%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=1-1494&node-type=frame&t=0QuLqtfzuABXHjnE-0

## 画面
![image](https://github.com/user-attachments/assets/49b6eb74-3808-4c04-8308-ecf0685fcd3d)

![image](https://github.com/user-attachments/assets/73f79888-955c-4afd-870d-4fc088efdbc1)

![image](https://github.com/user-attachments/assets/71907d0f-365d-4a95-a476-0cc28b65ae02)

