### PR TITLE
ヘッダーコンポーネントの作成

### DIFF
--- a/src/app/wip/page.tsx
+++ b/src/app/wip/page.tsx
@@ -1,0 +1,9 @@
+import { Header } from "../../components/ui/header";
+
+export default function Home() {
+  return (
+    <>
+      <Header />
+    </>
+  );
+}

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -1,0 +1,54 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export function Header() {
+  return (
+    <header className="fixed top-0 w-full bg-white z-50 h-[51px] flex items-center justify-between px-4 md:h-16 md:px-6">
+      <Link href="/" className="text-blue-600 font-bold text-xl">
+        <Image
+          src="/logo.svg"
+          alt="TSKaigi"
+          width={98}
+          height={36}
+          className="w-[78px] h-[28px] md:w-[98px] md:h-[36px]"
+        />
+      </Link>
+      <nav className="hidden md:block">
+        <ul className="flex gap-6 text-sm font-bold">
+          <li>
+            <Link
+              href="#mission"
+              className="text-link-light hover:text-link-dark"
+            >
+              ミッション
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="#proposal"
+              className="text-link-light hover:text-link-dark"
+            >
+              プロポーザル募集
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="#sponsors"
+              className="text-link-light hover:text-link-dark"
+            >
+              スポンサー一覧
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="#staff"
+              className="text-link-light hover:text-link-dark"
+            >
+              スタッフ
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export function Header() {
   return (
-    <header className="fixed top-0 w-full bg-white z-50 flex items-center justify-between p-4 md:px-6">
+    <header className="fixed top-0 w-full bg-white z-50 flex items-center justify-between shadow-sm p-4 md:px-6">
       <Link href="/" className="text-blue-600 font-bold text-xl">
         <Image
           src="/logo.svg"
@@ -13,42 +13,6 @@ export function Header() {
           className="w-[78px] h-[28px] md:w-[98px] md:h-[36px]"
         />
       </Link>
-      <nav className="hidden md:block">
-        <ul className="flex gap-6 text-sm font-bold">
-          <li>
-            <Link
-              href="#mission"
-              className="text-link-light hover:text-link-dark"
-            >
-              ミッション
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="#proposal"
-              className="text-link-light hover:text-link-dark"
-            >
-              プロポーザル募集
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="#sponsors"
-              className="text-link-light hover:text-link-dark"
-            >
-              スポンサー一覧
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="#staff"
-              className="text-link-light hover:text-link-dark"
-            >
-              スタッフ
-            </Link>
-          </li>
-        </ul>
-      </nav>
     </header>
   );
 }

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export function Header() {
   return (
-    <header className="fixed top-0 w-full bg-white z-50 h-[51px] flex items-center justify-between px-4 md:h-16 md:px-6">
+    <header className="fixed top-0 w-full bg-white z-50 flex items-center justify-between p-4 md:px-6">
       <Link href="/" className="text-blue-600 font-bold text-xl">
         <Image
           src="/logo.svg"


### PR DESCRIPTION
## 対応したこと

- ヘッダーコンポーネントの作成
- wipページの作成

## スクリーンショット

### sp

![image](https://github.com/user-attachments/assets/2b93161d-3e52-4e62-85b4-bf8238ac6954)

### pc

![image](https://github.com/user-attachments/assets/5a33395e-01b5-4b9f-8381-ca2e5fb07556)

## やらないこと

- フッターコンポーネントをwipページに移動
  - 間のmainの要素ができたら移動させる

## 補足

- tailwind.config.tsを使いたかったのでtsuyuni/20250101からブランチを切っています