### PR TITLE
プロポーザル募集のcompoennt を作成

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { ApplyToProposal } from "@/components/ApplyToProposal";
 import { EventCountdownBanner } from "@/components/EventCountdownBanner";
 import Footer from "@/components/Footer";
 import { SeekingSponsorsSection } from "@/components/SeekingSponsorsSection";
@@ -8,6 +9,7 @@ export default function Home() {
       <main className="w-full flex flex-col items-center">
         <EventCountdownBanner />
         <SeekingSponsorsSection />
+        <ApplyToProposal />
       </main>
       <Footer />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { ApplyToProposal } from "@/components/ApplyToProposal";
 import { EventCountdownBanner } from "@/components/EventCountdownBanner";
 import Footer from "@/components/Footer";
 import { SeekingSponsorsSection } from "@/components/SeekingSponsorsSection";
@@ -9,7 +8,6 @@ export default function Home() {
       <main className="w-full flex flex-col items-center">
         <EventCountdownBanner />
         <SeekingSponsorsSection />
-        <ApplyToProposal />
       </main>
       <Footer />
     </>

--- a/src/components/ApplyToProposal/index.tsx
+++ b/src/components/ApplyToProposal/index.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
-// TODO: position が整っていないので、整える
 export const ApplyToProposal = () => {
   return (
     <div className="bg-blue-light-400 flex items-center justify-center">

--- a/src/components/ApplyToProposal/index.tsx
+++ b/src/components/ApplyToProposal/index.tsx
@@ -1,74 +1,9 @@
+import { Decoration } from "@/components/Decoration";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
 // TODO: position が整っていないので、整える
-const Accent = () => {
-  return (
-    <div className="relative w-[21px] h-[6px] flex justify-end items-end -gap-7">
-      <div className="absolute top-0 right-0">
-        <svg
-          width="20"
-          height="6"
-          viewBox="0 0 20 6"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="shrink-0"
-        >
-          <title>下飾り(青)</title>
-          <path d="M3.5 0H20.5L17.5 6H0.5L3.5 0Z" fill="#6BADE8" />
-        </svg>
-        <svg
-          width="10"
-          height="4"
-          viewBox="0 0 10 4"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="absolute top-[2px]"
-        >
-          <title>下飾り(青)</title>
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M8.5 4H0.5L2.5 0H10.5L8.5 4Z"
-            fill="#0C7EDC"
-          />
-        </svg>
-      </div>
-
-      <div className="absolute bottom-0 left-0">
-        <svg
-          width="20"
-          height="6"
-          viewBox="0 0 20 6"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="shrink-0"
-        >
-          <title>下飾り(ピンク)</title>
-          <path d="M3.5 0H20.5L17.5 6H0.5L3.5 0Z" fill="#FFC0DB" />
-        </svg>
-        <svg
-          width="12"
-          height="5"
-          viewBox="0 0 12 5"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="absolute left-2 top-[3px]"
-        >
-          <title>下飾り(ピンク)</title>
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M10 5H0.5L3.35714 0H12.5L10 5Z"
-            fill="#FF86B9"
-          />
-        </svg>
-      </div>
-    </div>
-  );
-};
-
 export const ApplyToProposal = () => {
   return (
     <div className="bg-blue-light-400 flex items-center justify-center">
@@ -78,7 +13,7 @@ export const ApplyToProposal = () => {
             <h1 className="lg:text-[32px] md:text-[28px] text-[24px] font-bold text-center pb-4">
               プロポーザル募集
             </h1>
-            <Accent />
+            <Decoration />
           </div>
           <div className="py-6 md:py-6 lg:py-10">
             <p className="text-[16px] md:text-[18px] text-left">

--- a/src/components/ApplyToProposal/index.tsx
+++ b/src/components/ApplyToProposal/index.tsx
@@ -1,0 +1,111 @@
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+// TODO: position が整っていないので、整える
+const Accent = () => {
+  return (
+    <div className="relative w-[21px] h-[6px] flex justify-end items-end -gap-7">
+      <div className="absolute top-0 right-0">
+        <svg
+          width="20"
+          height="6"
+          viewBox="0 0 20 6"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="shrink-0"
+        >
+          <title>下飾り(青)</title>
+          <path d="M3.5 0H20.5L17.5 6H0.5L3.5 0Z" fill="#6BADE8" />
+        </svg>
+        <svg
+          width="10"
+          height="4"
+          viewBox="0 0 10 4"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="absolute top-[2px]"
+        >
+          <title>下飾り(青)</title>
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M8.5 4H0.5L2.5 0H10.5L8.5 4Z"
+            fill="#0C7EDC"
+          />
+        </svg>
+      </div>
+
+      <div className="absolute bottom-0 left-0">
+        <svg
+          width="20"
+          height="6"
+          viewBox="0 0 20 6"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="shrink-0"
+        >
+          <title>下飾り(ピンク)</title>
+          <path d="M3.5 0H20.5L17.5 6H0.5L3.5 0Z" fill="#FFC0DB" />
+        </svg>
+        <svg
+          width="12"
+          height="5"
+          viewBox="0 0 12 5"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="absolute left-2 top-[3px]"
+        >
+          <title>下飾り(ピンク)</title>
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M10 5H0.5L3.35714 0H12.5L10 5Z"
+            fill="#FF86B9"
+          />
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export const ApplyToProposal = () => {
+  return (
+    <div className="bg-blue-light-400 flex items-center justify-center">
+      <div className=" flex flex-col items-center justify-center md:p-10 lg:p-16 px-6 py-10 rounded-lg">
+        <div className="bg-white p-6 md:px-10 md:py-6 lg:py-16 lg:px-10 flex flex-col items-center rounded-lg">
+          <div className="flex flex-col items-center">
+            <h1 className="lg:text-[32px] md:text-[28px] text-[24px] font-bold text-center pb-4">
+              プロポーザル募集
+            </h1>
+            <Accent />
+          </div>
+          <div className="py-6 md:py-6 lg:py-10">
+            <p className="text-[16px] md:text-[18px] text-left">
+              プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。
+            </p>
+          </div>
+          <div className="flex justify-center">
+            <Button
+              asChild
+              variant="default"
+              size="lg"
+              className="rounded-full w-[280px] h-[60px] fill-primary bg-blue-purple-500 hover:bg-blue-purple-600 text-white"
+            >
+              {/* TODO: href を今年の プロポーザル募集のURL に変更 */}
+              <Link
+                href="https://docs.google.com/forms/d/e/1FAIpQLSfZR2TQr0E6CJ9l9hy9L9xvO5o6Ep5GXcZo57zq-7b_TEt52g/viewform"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-bold text-[22px] flex items-center space-x-2"
+              >
+                <span>抽選を申し込む</span>
+                <ArrowRight />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
issue: https://github.com/tskaigi/tskaigi2025-web-site/issues/31

# 対応したこと

- プロポーザル募集のコンポーネントを作成

# スクリーンショット

## sp(iPhone SE)

![スクリーンショット 2025-01-14 1 12 22](https://github.com/user-attachments/assets/1bd9952e-cf5f-44ad-bffd-bd531f3fa4c2)

## tablet(iPad mini)

![スクリーンショット 2025-01-14 1 12 10](https://github.com/user-attachments/assets/0fa999c5-b365-4def-b465-9b71427feec5)

## pc(1200 * 800)

![スクリーンショット 2025-01-14 1 11 48](https://github.com/user-attachments/assets/9e13ddf2-6400-4fd7-9642-ede6a7881a9d)

# やらないこと

- セクション下の飾りのスタイル調整が上手くできていません 🙇 （できなかった）

# 見ていただきたいこと

- 全体的なクラスの付け方が良さそうか
  - cursol に聞きつつやったのと、本職じゃないので、自身がないです
- figma の 開発者モードを使ってpixel などを合わせているので、問題ないはずですが、px 合ってそうかも見ていただけると幸いです






