### PR TITLE
wipページにマップとプロポーザル募集のコンポーネント追加

### DIFF
--- a/src/app/wip/page.tsx
+++ b/src/app/wip/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ApplyToProposalSection } from "../../components/ApplyToProposalSection";
 import Footer from "../../components/Footer";
 import { Header } from "../../components/Header";
 import { HeroSection } from "../../components/HeroSection";
@@ -16,6 +17,7 @@ export default function Home() {
       <main className="pt-16">
         <HeroSection />
         <MissionSection />
+        <ApplyToProposalSection />
         <SponsorsBoardSection />
       </main>
       <Footer />

--- a/src/components/ApplyToProposalSection/index.tsx
+++ b/src/components/ApplyToProposalSection/index.tsx
@@ -3,11 +3,11 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
-export const ApplyToProposal = () => {
+export const ApplyToProposalSection = () => {
   return (
     <div className="bg-blue-light-400 flex items-center justify-center">
-      <div className=" flex flex-col items-center justify-center md:p-10 lg:p-16 px-6 py-10 rounded-lg">
-        <div className="bg-white p-6 md:px-10 md:py-6 lg:py-16 lg:px-10 flex flex-col items-center rounded-lg">
+      <div className="flex flex-col items-center justify-center md:p-10 lg:p-16 px-6 py-10 rounded-lg">
+        <div className="bg-white p-6 md:px-10 md:py-6 lg:py-16 lg:px-10 flex flex-col items-center rounded-lg max-w-[940px]">
           <div className="flex flex-col items-center">
             <h1 className="lg:text-[32px] md:text-[28px] text-[24px] font-bold text-center pb-4">
               プロポーザル募集

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import Image from "next/image";
+import Link from "next/link";
 
 const Footer = () => {
   return (
@@ -12,15 +11,42 @@ const Footer = () => {
         </div>
 
         <ul className="flex flex-col gap-2.5 lg:w-72">
-          <li>スポンサー一覧</li>
+          {/* <li>スポンサー一覧</li> */}
         </ul>
 
         <div className="flex flex-col gap-3 lg:w-72">
           <p className="font-bold">公式アカウント</p>
           <ul className="flex flex-col gap-2.5 pl-3">
-            <li>公式X</li>
-            <li>Blog</li>
-            <li>公式Youtube</li>
+            <li>
+              <Link
+                href="https://x.com/tskaigi"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                公式X
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="https://tskaigi.hatenablog.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                Blog
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="https://www.youtube.com/@tskaigi"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                公式Youtube
+              </Link>
+            </li>
           </ul>
         </div>
       </div>

--- a/src/components/MissionSection/index.tsx
+++ b/src/components/MissionSection/index.tsx
@@ -1,4 +1,5 @@
 import { Decoration } from "../Decoration";
+import { VenueInformation } from "../VenueInformation";
 
 export function MissionSection() {
   return (
@@ -7,7 +8,7 @@ export function MissionSection() {
         background:
           "linear-gradient(180deg, rgba(133, 196, 255, 0.6) 0%, rgba(202, 230, 255, 0.6) 5.28%, rgba(233, 245, 255, 0.6) 8.92%)",
       }}
-      className="relative -mt-8 -z-10 md:-mt-16 lg:-mt-24"
+      className="relative -mt-8 z-10 md:-mt-16 lg:-mt-24"
     >
       <div className="p-6 flex flex-col justify-center md:p-10 lg:max-w-[940px] lg:mx-auto lg:py-10">
         <h2 className="text-sm text-center md:text-lg">MISSION</h2>
@@ -33,6 +34,7 @@ export function MissionSection() {
             新型コロナウイルスが落ち着いた今、各所で蓄積されたノウハウが日の目を浴び、より生き生きとTSエンジニアが働ける世界を目指して、TSKaigiを開催します。
           </p>
         </div>
+        <VenueInformation />
       </div>
     </section>
   );

--- a/src/components/VenueInformation/index.tsx
+++ b/src/components/VenueInformation/index.tsx
@@ -3,8 +3,8 @@ import Link from "next/link";
 
 export const VenueInformation = () => {
   return (
-    <section className="flex flex-col items-center text-center my-[24px] md:my-[40px] lg:my-[64px] bg-white px-[24px] md:px-[40px] lg:px-[40ox] rounded-lg">
-      <div className="py-[32px]">
+    <section className="flex flex-col items-center text-center mt-[24px] md:mt-[40px] lg:mt-[64px]">
+      <div className="py-[32px] rounded-lg bg-white px-[24px] md:px-[40px] lg:px-[40ox] w-full max-w-[740px]">
         <div className="space-y-1 mb-8 px-6">
           <h2>
             開催:
@@ -18,10 +18,10 @@ export const VenueInformation = () => {
               href="https://www.bellesalle.co.jp/shisetsu/tokyo/bs_kanda/"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center text-link-light"
+              className="inline-flex items-center text-link-light font-bold hover:underline"
             >
               ベルサール神田
-              <ExternalLink className="ml-2 text-link-light" />
+              <ExternalLink className="ml-2 text-link-light" aria-hidden />
             </Link>
           </p>
         </div>
@@ -30,7 +30,7 @@ export const VenueInformation = () => {
             src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d12961.373481111958!2d139.765497!3d35.693167!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188c04e343e62b%3A0x2692b8958204057a!2z44OZ44Or44K144O844Or56We55Sw!5e0!3m2!1sja!2sjp!4v1737291027030!5m2!1sja!2sjp"
             width="100%"
             height="100%"
-            className="border-0 w-[327px] h-[380px] md:w-[608px] md:h-[380px] lg:w-[660px] lg:h-[380px]"
+            className="border-0 h-[380px] md:h-[380px] lg:h-[380px]"
             allowFullScreen={true}
             loading="lazy"
             referrerPolicy="no-referrer-when-downgrade"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -143,11 +143,6 @@ const config: Config = {
           "5": "hsl(var(--chart-5))",
         },
       },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
       fontFamily: {
         outfit: ["var(--font-outfit)"],
         noto: ["var(--font-noto)"],


### PR DESCRIPTION
## やったこと

- wipページにマップとプロポーザル募集のコンポーネント追加
- 軽微なスタイル修正
- footerのリンク追加

## スクショ
スクショだとheaderの一がなぜかおかしくなってますが、普段は大丈夫だと思います。

| SP | TAB | PC |
|--------|--------|--------|
| ![localhost_3000_wip (4)](https://github.com/user-attachments/assets/809064a3-8519-4f7d-9e9c-f16dd3eda60a) | ![localhost_3000_wip (5)](https://github.com/user-attachments/assets/eaab560b-4a96-4723-b819-3148ec9fc765) | ![localhost_3000_wip (6)](https://github.com/user-attachments/assets/da9e5129-c347-4d37-a5ae-3271aae9af8b)| 
