### PR TITLE
プロポーザル募集の文言修正と、遷移先の修正

### DIFF
--- a/src/components/ApplyToProposalSection/index.tsx
+++ b/src/components/ApplyToProposalSection/index.tsx
@@ -15,9 +15,21 @@ export const ApplyToProposalSection = () => {
             <Decoration />
           </div>
           <div className="py-6 md:py-6 lg:py-10">
-            <p className="text-[16px] md:text-[18px] text-left">
-              プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。プロポーザル募集についてのテキストが入ります。
-            </p>
+            <div className="text-[16px] md:text-[18px] text-left">
+              <p>
+                TSKaigiは、節目となる発表の場を通じてエンジニアのアウトプットを促進し、日本のTypeScriptコミュニティを盛り上げるTypeScriptカンファレンスです！
+              </p>
+              <p>
+                私たちの願いは、フロントエンドからバックエンド、インフラに至るまで、多様な分野のTypeScriptエンジニアたちが集い、普段は交流の少ないエンジニアたちが、それぞれの得意分野や最新の知見を交換し合う交流の場を創り出すことです。
+              </p>
+              <p>
+                経験のある方も初めて登壇される方にとっても、このカンファレンスが人生の新たな節目になることを願っています。
+              </p>
+              <p>
+                あなたの発表が、誰かのキャリア、あるいはプロジェクトに新たな光をもたらすかもしれません。
+              </p>
+              <p>ぜひ一緒に日本のTypeScriptコミュニティを盛り上げましょう！</p>
+            </div>
           </div>
           <div className="flex justify-center">
             <Button
@@ -26,9 +38,8 @@ export const ApplyToProposalSection = () => {
               size="lg"
               className="rounded-full w-[280px] h-[60px] fill-primary bg-blue-purple-500 hover:bg-blue-purple-600 text-white"
             >
-              {/* TODO: href を今年の プロポーザル募集のURL に変更 */}
               <Link
-                href="https://docs.google.com/forms/d/e/1FAIpQLSfZR2TQr0E6CJ9l9hy9L9xvO5o6Ep5GXcZo57zq-7b_TEt52g/viewform"
+                href="https://docs.google.com/forms/d/e/1FAIpQLScKXPc8dLC3QSqu_pMTGJdED3LuuFi0QCVsCMWIrC6nPcxRnA/viewform"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-bold text-[22px] flex items-center space-x-2"


### PR DESCRIPTION
# やったこと

- プロポーザル募集の文言と、遷移先をプログラムチームから共有いただいたため、反映しました

（間違えてdevelop で直接作業してしまったので、revert して、branch を切って作業しました）

# スクリーンショット

## PC

![スクリーンショット 2025-01-28 20 36 07](https://github.com/user-attachments/assets/6d529585-e69d-4aa2-abc8-7ce8d5fb455c)

## iPad mini

![スクリーンショット 2025-01-28 20 36 24](https://github.com/user-attachments/assets/a8569528-e4d6-4b7d-bd80-3d48542ec8d9)


## iPhone SE

![スクリーンショット 2025-01-28 20 36 45](https://github.com/user-attachments/assets/18215a30-1c3b-4e89-b338-118070f6bb48)

![スクリーンショット 2025-01-28 20 36 53](https://github.com/user-attachments/assets/fb45f4f8-828f-44fb-b776-9f8b01c88ad3)

