### PR TITLE
fix: ヒーローセクションのアスペクト比を変更し、オーバーフローを隠すスタイルを追加

### DIFF
--- a/src/app/wip/page.tsx
+++ b/src/app/wip/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
   return (
     <>
       <Header />
-      <main className="pt-8">
+      <main className="pt-8 overflow-x-hidden">
         <HeroSectionWithMotion />
         <MissionSection />
         <ApplyToProposalSection />

--- a/src/components/HeroSectionWithMotion/index.tsx
+++ b/src/components/HeroSectionWithMotion/index.tsx
@@ -135,7 +135,7 @@ export function HeroSectionWithMotion() {
   return (
     <div
       ref={mvWrapperRef}
-      className="relative max-w-[1280px] mx-auto aspect-[16/9]"
+      className="relative max-w-[1280px] mx-auto aspect-[32/15]"
     >
       <img
         className="fadein absolute top-[20.4%] left-[87.95%] w-[11.5%] h-auto origin-bottom-left"
@@ -218,7 +218,7 @@ export function HeroSectionWithMotion() {
         </svg>
       </div>
 
-      <div className="absolute top-0 left-[53%] w-[46%] pt-[53%] origin-center">
+      <div className="absolute top-0 left-[53%] w-[53%] pt-[53%] origin-center ">
         <svg
           className="w-full h-full absolute top-0 left-0 overflow-visible"
           ref={rightRippleSvg}


### PR DESCRIPTION
## やったこと

- 猪野さんと話しつつメインビジュアルの修正を行いました

## スクショ

![image](https://github.com/user-attachments/assets/e4b867b3-3591-459c-9a26-c1d43a8038dc)

![image](https://github.com/user-attachments/assets/76a4db46-b00e-4419-841e-7bbb01398743)

![image](https://github.com/user-attachments/assets/f32cca97-d28a-4267-bf86-18e0fd4f1262)
