### PR TITLE
feat: スポンサー詳細ページの作成

### DIFF
--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,9 +1,9 @@
 import Footer from "@/components/Footer";
 import { Header } from "@/components/Header";
-import Company from "@/components/Sponsors/Company";
-import SponsorHeading from "@/components/Sponsors/SponsorHeading";
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
+import SponsorHeading from "@/components/sponsors/SponsorHeading";
+import Company from "@/components/sponsors/Company";
 
 const SponsorsPage = () => {
   return (

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,8 +1,8 @@
 import Footer from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
-import Company from "@/components/sponsors/Company";
-import SponsorHeading from "@/components/sponsors/SponsorHeading";
+import Company from "@/components/Sponsors/Company";
+import SponsorHeading from "@/components/Sponsors/SponsorHeading";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 
 const SponsorsPage = () => {

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,9 +1,9 @@
 import Footer from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
-import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
-import SponsorHeading from "@/components/sponsors/SponsorHeading";
 import Company from "@/components/sponsors/Company";
+import SponsorHeading from "@/components/sponsors/SponsorHeading";
+import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 
 const SponsorsPage = () => {
   return (

--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -1,8 +1,8 @@
 import Footer from "@/components/Footer";
 import { Header } from "@/components/Header";
-import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
 import Company from "@/components/Sponsors/Company";
 import SponsorHeading from "@/components/Sponsors/SponsorHeading";
+import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 
 const SponsorsPage = () => {

--- a/src/app/wip/layout.tsx
+++ b/src/app/wip/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const metadata: Metadata = {
+  robots: "noindex, nofollow",
+};
+
+export default function WipLayout({ children }: Props) {
+  return <>{children}</>;
+}

--- a/src/app/wip/page.tsx
+++ b/src/app/wip/page.tsx
@@ -1,16 +1,11 @@
 import { CoreStaffSection } from "@/components/CoreStaffSection";
 import { JudgesSection } from "@/components/JudgesSection";
-import type { Metadata } from "next";
 import { ApplyToProposalSection } from "../../components/ApplyToProposalSection";
 import Footer from "../../components/Footer";
 import { Header } from "../../components/Header";
 import { HeroSectionWithMotion } from "../../components/HeroSectionWithMotion";
 import { MissionSection } from "../../components/MissionSection";
 import { SponsorsBoardSection } from "../../components/SponsorsBoardSection";
-
-export const metadata: Metadata = {
-  robots: "noindex, nofollow",
-};
 
 export default function Home() {
   return (

--- a/src/app/wip/sponsors/[id]/page.tsx
+++ b/src/app/wip/sponsors/[id]/page.tsx
@@ -1,7 +1,7 @@
-import { sponsorId } from "@/constants/sponsorList";
-import { getSponsor } from "@/utils/getSponsor";
 import ExternalLink from "@/components/sponsors/ExternalLink";
 import RoleBadge from "@/components/sponsors/RoleBadge";
+import { sponsorId } from "@/constants/sponsorList";
+import { getSponsor } from "@/utils/getSponsor";
 
 export async function generateStaticParams() {
   return sponsorId;

--- a/src/app/wip/sponsors/[id]/page.tsx
+++ b/src/app/wip/sponsors/[id]/page.tsx
@@ -25,7 +25,7 @@ export default async function SponserDetailPage({
             <img
               width="800"
               height="400"
-              className="w-full max-w-[800px] mx-auto"
+              className="w-full max-w-[800px] h-auto max-h-[400px] mx-auto object-contain"
               src={sponsor.logoImage}
               alt="logo"
             />

--- a/src/app/wip/sponsors/[id]/page.tsx
+++ b/src/app/wip/sponsors/[id]/page.tsx
@@ -10,7 +10,7 @@ export async function generateStaticParams() {
 
 export default async function SponserDetailPage({
   params,
-}: { params: Promise<{id: string}> }) {
+}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const sponsor = getSponsor(id);
 
@@ -24,8 +24,8 @@ export default async function SponserDetailPage({
         <div className="bg-white p-6 flex flex-col gap-10 max-w-screen-xl mx-auto md:rounded-xl lg:p-10">
           <div>
             <img
-              width='800'
-              height='400'
+              width="800"
+              height="400"
               className="w-full max-w-[800px] mx-auto"
               src={sponsor.logoImage}
               alt="logo"
@@ -33,13 +33,15 @@ export default async function SponserDetailPage({
           </div>
 
           <div className="flex flex-col gap-6">
-            <div className='flex gap-2'>
+            <div className="flex gap-2">
               {sponsor.roles.map((role) => (
                 <RoleBadge key={role} role={role} />
               ))}
             </div>
 
-            <p className="font-bold text-xl md:text-2xl lg:text-[28px]">{sponsor.name}</p>
+            <p className="font-bold text-xl md:text-2xl lg:text-[28px]">
+              {sponsor.name}
+            </p>
 
             {sponsor.overview?.map((overview) => (
               <p key={overview}>{overview}</p>

--- a/src/app/wip/sponsors/[id]/page.tsx
+++ b/src/app/wip/sponsors/[id]/page.tsx
@@ -1,0 +1,60 @@
+import ExternalLink from "@/components/Sponsors/ExternalLink";
+import RoleBadge from "@/components/Sponsors/RoleBadge";
+
+import { sponsorId } from "@/constants/sponsorList";
+import { getSponsor } from "@/utils/getSponsor";
+
+export async function generateStaticParams() {
+  return sponsorId;
+}
+
+export default async function SponserDetailPage({
+  params,
+}: { params: Promise<{id: string}> }) {
+  const { id } = await params;
+  const sponsor = getSponsor(id);
+
+  return (
+    <main>
+      <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
+        スポンサー詳細
+      </h1>
+
+      {sponsor && (
+        <div className="bg-white p-6 flex flex-col gap-10 max-w-screen-xl mx-auto md:rounded-xl lg:p-10">
+          <div>
+            <img
+              width='800'
+              height='400'
+              className="w-full max-w-[800px] mx-auto"
+              src={sponsor.logoImage}
+              alt="logo"
+            />
+          </div>
+
+          <div className="flex flex-col gap-6">
+            <div className='flex gap-2'>
+              {sponsor.roles.map((role) => (
+                <RoleBadge key={role} role={role} />
+              ))}
+            </div>
+
+            <p className="font-bold text-xl md:text-2xl lg:text-[28px]">{sponsor.name}</p>
+
+            {sponsor.overview?.map((overview) => (
+              <p key={overview}>{overview}</p>
+            ))}
+          </div>
+
+          <ul className="list-disc list-inside flex flex-col gap-y-2">
+            {sponsor.links?.map((link) => (
+              <li key={link.title}>
+                <ExternalLink title={link.title} href={link.href} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/app/wip/sponsors/[id]/page.tsx
+++ b/src/app/wip/sponsors/[id]/page.tsx
@@ -1,8 +1,7 @@
-import ExternalLink from "@/components/Sponsors/ExternalLink";
-import RoleBadge from "@/components/Sponsors/RoleBadge";
-
 import { sponsorId } from "@/constants/sponsorList";
 import { getSponsor } from "@/utils/getSponsor";
+import ExternalLink from "@/components/sponsors/ExternalLink";
+import RoleBadge from "@/components/sponsors/RoleBadge";
 
 export async function generateStaticParams() {
   return sponsorId;

--- a/src/app/wip/sponsors/layout.tsx
+++ b/src/app/wip/sponsors/layout.tsx
@@ -1,0 +1,16 @@
+import Footer from "@/components/Footer";
+import { Header } from "@/components/Header";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function SponsorLayout({ children }: Props) {
+  return (
+    <>
+      <Header />
+      <main className="bg-blue-light-100 pt-16 py-10 md:px-8">{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/wip/sponsors/page.tsx
+++ b/src/app/wip/sponsors/page.tsx
@@ -1,8 +1,8 @@
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
+import Company from "@/components/sponsors/Company";
+import SponsorHeading from "@/components/sponsors/SponsorHeading";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 import type { Metadata } from "next";
-import SponsorHeading from "@/components/sponsors/SponsorHeading";
-import Company from "@/components/sponsors/Company";
 
 export const metadata: Metadata = {
   robots: "noindex, nofollow",

--- a/src/app/wip/sponsors/page.tsx
+++ b/src/app/wip/sponsors/page.tsx
@@ -1,8 +1,8 @@
-import Company from "@/components/Sponsors/Company";
-import SponsorHeading from "@/components/Sponsors/SponsorHeading";
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 import type { Metadata } from "next";
+import SponsorHeading from "@/components/sponsors/SponsorHeading";
+import Company from "@/components/sponsors/Company";
 
 export const metadata: Metadata = {
   robots: "noindex, nofollow",

--- a/src/app/wip/sponsors/page.tsx
+++ b/src/app/wip/sponsors/page.tsx
@@ -1,8 +1,6 @@
-import Footer from "@/components/Footer";
-import { Header } from "@/components/Header";
+import Company from "@/components/Sponsors/Company";
+import SponsorHeading from "@/components/Sponsors/SponsorHeading";
 import { SponsorsBoardItem } from "@/components/SponsorsBoardSection/SponsorsBoardItem";
-import Company from "@/components/sponsors/Company";
-import SponsorHeading from "@/components/sponsors/SponsorHeading";
 import { type SponsorClass, sponsorList } from "@/constants/sponsorList";
 import type { Metadata } from "next";
 
@@ -12,54 +10,50 @@ export const metadata: Metadata = {
 
 const SponsorsPage = () => {
   return (
-    <>
-      <Header />
-      <main className="bg-blue-light-100 pt-16 py-10 md:px-8">
-        <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
-          スポンサー一覧
-        </h1>
+    <main className="bg-blue-light-100 pt-16 py-10 md:px-8">
+      <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
+        スポンサー一覧
+      </h1>
 
-        <div className="bg-white p-6 flex flex-col gap-10 max-w-screen-xl mx-auto md:rounded-xl lg:p-10">
-          {Object.entries(sponsorList).map(([key, value]) => {
-            return (
-              <div key={key} className="flex flex-col gap-12">
-                <SponsorHeading variant={key as SponsorClass} />
+      <div className="bg-white p-6 flex flex-col gap-10 max-w-screen-xl mx-auto md:rounded-xl lg:p-10">
+        {Object.entries(sponsorList).map(([key, value]) => {
+          return (
+            <div key={key} className="flex flex-col gap-12">
+              <SponsorHeading variant={key as SponsorClass} />
 
-                {key !== "bronze" ? (
-                  <ul className="flex flex-col gap-6">
-                    {value.map((company, idx, value) => (
-                      <li key={company.name} className="flex flex-col gap-6">
-                        <Company {...company} />
-                        {idx !== value.length - 1 && (
-                          <hr className="border-t-2 border-black-200" />
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <ul className="grid grid-cols-2 gap-4 md:grid-cols-5">
-                    {value.map((company, idx, value) => (
-                      <li key={company.name}>
-                        <SponsorsBoardItem
-                          key={company.id}
-                          className={`w-full h-[96px] ${company.addPadding ? "p-4" : "p-2"}`}
-                          src={company.logoImage}
-                          alt={company.name}
-                          href={company.logoLink}
-                          width={211}
-                          height={96}
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </main>
-      <Footer />
-    </>
+              {key !== "bronze" ? (
+                <ul className="flex flex-col gap-6">
+                  {value.map((company, idx, value) => (
+                    <li key={company.name} className="flex flex-col gap-6">
+                      <Company {...company} />
+                      {idx !== value.length - 1 && (
+                        <hr className="border-t-2 border-black-200" />
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <ul className="grid grid-cols-2 gap-4 md:grid-cols-5">
+                  {value.map((company, idx, value) => (
+                    <li key={company.name}>
+                      <SponsorsBoardItem
+                        key={company.id}
+                        className={`w-full h-[96px] ${company.addPadding ? "p-4" : "p-2"}`}
+                        src={company.logoImage}
+                        alt={company.name}
+                        href={company.logoLink}
+                        width={211}
+                        height={96}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </main>
   );
 };
 

--- a/src/components/sponsors/RoleBadge/index.tsx
+++ b/src/components/sponsors/RoleBadge/index.tsx
@@ -11,7 +11,7 @@ const bgColor: { [key in SponsorRole]: string } = {
   "naming-rights": "bg-black-500",
 };
 
-const roleBadge = ({ role }: { role: SponsorRole }) => {
+const RoleBadge = ({ role }: { role: SponsorRole }) => {
   return (
     <span
       className={`font-bold text-sm text-white px-3 py-1 rounded-s rounded-e ${bgColor[role]}`}
@@ -21,4 +21,4 @@ const roleBadge = ({ role }: { role: SponsorRole }) => {
   );
 };
 
-export default roleBadge;
+export default RoleBadge;

--- a/src/constants/sponsorList.ts
+++ b/src/constants/sponsorList.ts
@@ -937,3 +937,11 @@ export const sponsorList: SponsorList = {
     },
   ],
 };
+
+// スポンサー詳細ページで使用するスポンサーIDのリスト
+export const sponsorId = [
+  ...sponsorList.platinum.map((sponsor) => ({ id: sponsor.id })),
+  ...sponsorList.gold.map((sponsor) => ({ id: sponsor.id })),
+  ...sponsorList.silver.map((sponsor) => ({ id: sponsor.id })),
+  ...sponsorList.bronze.map((sponsor) => ({ id: sponsor.id })),
+];

--- a/src/constants/sponsorList.ts
+++ b/src/constants/sponsorList.ts
@@ -13,6 +13,7 @@ export type Sponsor = {
   overview?: string[];
   links?: ExternalLinkProps[];
   roles: SponsorRole[];
+  detailPageId?: string;
 };
 
 type SponsorList = {
@@ -47,6 +48,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum", "naming-rights"],
+      detailPageId: "ascend",
     },
     {
       id: "P02",
@@ -65,6 +67,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum"],
+      detailPageId: "craft-bank",
     },
     {
       id: "P03",
@@ -87,6 +90,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum"],
+      detailPageId: "avita",
     },
     {
       id: "P04",
@@ -120,6 +124,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum"],
+      detailPageId: "nstock",
     },
     {
       id: "P05",
@@ -149,6 +154,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum", "beer"],
+      detailPageId: "dinii",
     },
     {
       id: "P06",
@@ -174,6 +180,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["platinum"],
+      detailPageId: "twogate",
     },
   ],
   gold: [
@@ -208,6 +215,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold", "naming-rights"],
+      detailPageId: "leverages",
     },
     {
       id: "G02",
@@ -236,6 +244,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "kinto-technologies",
     },
     {
       id: "G03",
@@ -263,6 +272,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "cyberagent",
     },
     {
       id: "G04",
@@ -290,6 +300,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "kepple",
     },
     {
       id: "G05",
@@ -318,6 +329,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "kaminashi",
     },
     {
       id: "G06",
@@ -347,6 +359,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "gmo-flatt-security",
     },
     {
       id: "G07",
@@ -375,6 +388,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "toggle",
     },
     {
       id: "G08",
@@ -399,6 +413,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "carta",
     },
     {
       id: "G09",
@@ -433,6 +448,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "caddi",
     },
     {
       id: "G10",
@@ -461,6 +477,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "stmn",
     },
     {
       id: "G11",
@@ -489,6 +506,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "ubie",
     },
     {
       id: "G12",
@@ -517,6 +535,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["gold"],
+      detailPageId: "takumi-giken",
     },
   ],
   silver: [
@@ -546,6 +565,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "theoria-technologies",
     },
     {
       id: "S03",
@@ -573,6 +593,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "linc-well",
     },
     {
       id: "S05",
@@ -597,6 +618,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "earthbrain",
     },
     {
       id: "S06",
@@ -625,6 +647,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "mosh",
     },
     {
       id: "S08",
@@ -644,6 +667,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver", "coffee"],
+      detailPageId: "kakehashi",
     },
     {
       id: "S11",
@@ -671,6 +695,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "medley",
     },
     {
       id: "S12",
@@ -698,6 +723,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "dwango",
     },
     {
       id: "S13",
@@ -726,6 +752,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "optim",
     },
     {
       id: "S14",
@@ -749,6 +776,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "tokium",
     },
     {
       id: "S15",
@@ -776,6 +804,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "freee",
     },
     {
       id: "S18",
@@ -805,6 +834,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "forcia",
     },
     {
       id: "S20",
@@ -833,6 +863,7 @@ export const sponsorList: SponsorList = {
         },
       ],
       roles: ["silver"],
+      detailPageId: "spacemarket",
     },
   ],
   bronze: [
@@ -940,7 +971,7 @@ export const sponsorList: SponsorList = {
 
 // スポンサー詳細ページで使用するスポンサーIDのリスト
 export const sponsorId = [
-  ...sponsorList.platinum.map((sponsor) => ({ id: sponsor.id })),
-  ...sponsorList.gold.map((sponsor) => ({ id: sponsor.id })),
-  ...sponsorList.silver.map((sponsor) => ({ id: sponsor.id })),
+  ...sponsorList.platinum.map((sponsor) => ({ id: sponsor.detailPageId })),
+  ...sponsorList.gold.map((sponsor) => ({ id: sponsor.detailPageId })),
+  ...sponsorList.silver.map((sponsor) => ({ id: sponsor.detailPageId })),
 ];

--- a/src/constants/sponsorList.ts
+++ b/src/constants/sponsorList.ts
@@ -943,5 +943,4 @@ export const sponsorId = [
   ...sponsorList.platinum.map((sponsor) => ({ id: sponsor.id })),
   ...sponsorList.gold.map((sponsor) => ({ id: sponsor.id })),
   ...sponsorList.silver.map((sponsor) => ({ id: sponsor.id })),
-  ...sponsorList.bronze.map((sponsor) => ({ id: sponsor.id })),
 ];

--- a/src/utils/getSponsor.ts
+++ b/src/utils/getSponsor.ts
@@ -9,7 +9,7 @@ import type { Sponsor } from "@/constants/sponsorList";
 export function getSponsor(id: string): Sponsor {
   const sponsor = Object.values(sponsorList)
     .flat()
-    .find((sponsor) => sponsor.id === id);
+    .find((sponsor) => sponsor.detailPageId === id);
 
   if (!sponsor) {
     throw new Error(`スポンサーが見つかりませんでした。id: ${id}`);

--- a/src/utils/getSponsor.ts
+++ b/src/utils/getSponsor.ts
@@ -1,0 +1,17 @@
+import { sponsorList } from '@/constants/sponsorList';
+import type { Sponsor } from '@/constants/sponsorList';
+
+/**
+ * IDを元にスポンサー情報を取得する
+ * @param id - スポンサーのID
+ * @returns スポンサー情報
+ */
+export function getSponsor (id: string): Sponsor {
+  const sponsor = Object.values(sponsorList).flat().find((sponsor) => sponsor.id === id);
+
+  if (!sponsor) {
+    throw new Error(`スポンサーが見つかりませんでした。id: ${id}`);
+  }
+
+  return sponsor;
+};

--- a/src/utils/getSponsor.ts
+++ b/src/utils/getSponsor.ts
@@ -1,17 +1,19 @@
-import { sponsorList } from '@/constants/sponsorList';
-import type { Sponsor } from '@/constants/sponsorList';
+import { sponsorList } from "@/constants/sponsorList";
+import type { Sponsor } from "@/constants/sponsorList";
 
 /**
  * IDを元にスポンサー情報を取得する
  * @param id - スポンサーのID
  * @returns スポンサー情報
  */
-export function getSponsor (id: string): Sponsor {
-  const sponsor = Object.values(sponsorList).flat().find((sponsor) => sponsor.id === id);
+export function getSponsor(id: string): Sponsor {
+  const sponsor = Object.values(sponsorList)
+    .flat()
+    .find((sponsor) => sponsor.id === id);
 
   if (!sponsor) {
     throw new Error(`スポンサーが見つかりませんでした。id: ${id}`);
   }
 
   return sponsor;
-};
+}


### PR DESCRIPTION
## 対応内容

以下の内容を対応しました。

- スポンサー詳細ページの作成（wipのみ）
- スポンサー一覧ページとスポンサー詳細ページのレイアウトを共通化（改善の余地ありそう...）
- コンポーネント名の修正
  - https://github.com/tskaigi/tskaigi2025-web-site/pull/121#discussion_r1981429283

以下の内容は対応していません。

- OGPの作成
- wipではないスポンサー詳細ページ

## 概要

- `/code-of-conduct` にページを追加
  - 事前チェックはないので本番用のページに追加
- ページへの動線は別 PR で作成

## スクリーンショット

| PC | Tablet | SP |
| --- | --- | --- |
| ![pc](https://github.com/user-attachments/assets/916fdfdf-f008-4dc4-a752-52dc150fe2ad) | ![tablet](https://github.com/user-attachments/assets/5015d9a0-81b4-4745-9049-f30d5dfd17ed) | ![sp](https://github.com/user-attachments/assets/27e8bffb-1f58-4fa5-af40-b8e305395be3) |

## 相談事項

- `/wip/sponsors/XXXX`の`XXXX`の部分
