### PR TITLE
スポンサー一覧ページからスポンサー詳細ページへ遷移できるようにする

### DIFF
--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -24,7 +24,7 @@ const SponsorsPage = () => {
                   <ul className="flex flex-col gap-6">
                     {value.map((company, idx, value) => (
                       <li key={company.name} className="flex flex-col gap-6">
-                        <Company {...company} />
+                        <Company isWip={false} {...company} />
                         {idx !== value.length - 1 && (
                           <hr className="border-t-2 border-black-200" />
                         )}

--- a/src/app/wip/sponsors/page.tsx
+++ b/src/app/wip/sponsors/page.tsx
@@ -25,7 +25,7 @@ const SponsorsPage = () => {
                 <ul className="flex flex-col gap-6">
                   {value.map((company, idx, value) => (
                     <li key={company.name} className="flex flex-col gap-6">
-                      <Company {...company} />
+                      <Company isWip={true} {...company} />
                       {idx !== value.length - 1 && (
                         <hr className="border-t-2 border-black-200" />
                       )}

--- a/src/components/sponsors/Company/index.tsx
+++ b/src/components/sponsors/Company/index.tsx
@@ -1,7 +1,12 @@
 import type { Sponsor } from "@/constants/sponsorList";
 import Image from "next/image";
+import Link from "next/link";
 import ExternalLink from "../ExternalLink";
 import RoleBadge from "../RoleBadge";
+
+type Props = Sponsor & {
+  isWip: boolean;
+};
 
 const Company = ({
   name,
@@ -10,16 +15,33 @@ const Company = ({
   overview,
   roles,
   links,
-}: Sponsor) => {
+  detailPageId,
+  isWip,
+}: Props) => {
   return (
     <div className="flex flex-col gap-y-3 md:flex-row md:items-start md:gap-x-8 lg:gap-x-10">
-      <Image
-        src={logoImageForSponsorsPage || logoImage}
-        alt={name}
-        width={1280}
-        height={640}
-        className="flex-shrink-0 md:w-1/3 lg:w-1/4 aspect-video lg:aspect-video object-contain"
-      />
+      {isWip ? (
+        <Link
+          href={`/wip/sponsors/${detailPageId}`}
+          className="flex-shrink-0 md:w-1/3 lg:w-1/4"
+        >
+          <Image
+            src={logoImageForSponsorsPage || logoImage}
+            alt={name}
+            width={1280}
+            height={640}
+            className="w-full aspect-video lg:aspect-video object-contain"
+          />
+        </Link>
+      ) : (
+        <Image
+          src={logoImageForSponsorsPage || logoImage}
+          alt={name}
+          width={1280}
+          height={640}
+          className="flex-shrink-0 md:w-1/3 lg:w-1/4 aspect-video lg:aspect-video object-contain"
+        />
+      )}
 
       <div className="flex flex-col gap-y-3">
         <div className="flex gap-2">


### PR DESCRIPTION
## 対応内容

以下の内容を対応しました。
- WIPの場合、スポンサー一覧ページの企業ロゴを押下時にスポンサー詳細ページへ遷移できるようにする
- WIPではない場合、スポンサー一覧ページの企業ロゴは押下できないようにする

以下の内容は対応していません。
- OGPの作成
- wipではないスポンサー詳細ページ