### PR TITLE
トップページにチケット購入セクションを追加 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       <Header />
       <main className="pt-8 overflow-x-hidden">
         <HeroSectionWithMotion />
-        <MissionSection />
+        <MissionSection isFirstSection={true} />
         <SponsorsBoardSection />
         <JudgesSection />
         <CoreStaffSection />

--- a/src/app/wip/page.tsx
+++ b/src/app/wip/page.tsx
@@ -13,8 +13,8 @@ export default function Home() {
       <Header />
       <main className="pt-8 overflow-x-hidden">
         <HeroSectionWithMotion />
-        <MissionSection />
         <BuyTicketSection />
+        <MissionSection isFirstSection={false} />
         <SponsorsBoardSection />
         <JudgesSection />
         <CoreStaffSection />

--- a/src/components/BuyTicketSection/index.tsx
+++ b/src/components/BuyTicketSection/index.tsx
@@ -2,6 +2,7 @@ import { Decoration } from "@/components/Decoration";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
+import { SectionGradation } from "../ui/sectionGradation";
 
 const BuyTicketPageLink = {
   offline: "https://peatix.com/event/4342134",
@@ -10,17 +11,17 @@ const BuyTicketPageLink = {
 
 export const BuyTicketSection = () => {
   return (
-    <div className="bg-blue-light-400 flex items-center justify-center">
-      <div className="flex flex-col items-center justify-center md:p-10 lg:p-16 px-6 py-10">
-        <div className="bg-white p-6 md:px-10 md:py-6 lg:py-6 lg:px-10 flex flex-col items-center rounded-lg  md:rounded-2xl max-w-[940px]">
-          <div className="flex flex-col items-center">
+    <SectionGradation>
+      <div className="p-6 flex flex-col justify-center md:p-10 lg:max-w-[940px] lg:mx-auto lg:py-16">
+        <div className="bg-white p-6 md:px-10 md:py-6 lg:py-10 lg:px-16 flex flex-col items-center rounded-lg  md:rounded-2xl max-w-[940px]">
+          <div className="flex flex-col items-center md:px-6 self-stretch">
             <h2 className="lg:text-[32px] md:text-[28px] text-[24px] font-bold text-center pb-4">
-              チケット購入
+              チケットを購入
             </h2>
             <Decoration />
           </div>
-          <div className="py-6 md:py-6 lg:py-10">
-            <div className="text-[16px] md:text-[18px] text-left leading-[1.8]">
+          <div className="flex py-6 lg:py-10">
+            <div className="text-[16px] md:text-[18px] text-left leading-[1.8] self-stretch">
               <p>
                 日本最大級のTypeScriptをテーマとした技術カンファレンス「TSKaigi
                 2025」開催決定！
@@ -38,12 +39,12 @@ export const BuyTicketSection = () => {
               <p>チケットの購入は以下より行えます。</p>
             </div>
           </div>
-          <div className="flex flex-col justify-center gap-4 md:flex-col lg:flex-row">
+          <div className="flex flex-col justify-center gap-5 md:flex-col lg:flex-row p-[10px] flex-1">
             <Button
               asChild
               variant="default"
               size="lg"
-              className="rounded-full h-[60px] bg-blue-purple-500 hover:bg-blue-purple-600 text-white pl-10 pr-8"
+              className="rounded-full h-[60px] bg-blue-purple-500 hover:bg-blue-purple-600 text-white pl-8 pr-6 md:pl-10 md:pr-8 lg:pl-10 lg:pr-8 self-stretch"
             >
               <Link
                 href={BuyTicketPageLink.offline}
@@ -51,7 +52,9 @@ export const BuyTicketSection = () => {
                 rel="noopener noreferrer"
                 className="font-bold flex items-center text-22 [&_svg]:size-6"
               >
-                <span className="text-18 leading-[1.8]">現地参加はこちら</span>
+                <span className="text-18 lg:text-22 leading-[1.8]">
+                  現地参加チケット
+                </span>
                 <ArrowRight />
               </Link>
             </Button>
@@ -59,7 +62,7 @@ export const BuyTicketSection = () => {
               asChild
               variant="default"
               size="lg"
-              className="rounded-full h-[60px] bg-blue-purple-500 hover:bg-blue-purple-600 text-white pl-10 pr-8"
+              className="rounded-full h-[60px] bg-white hover:bg-blue-purple-600 text-blue-purple-500 pl-8 pr-6 md:pl-10 md:pr-8 lg:pl-10 lg:pr-8 border-[2px] border-black-500 self-stretch"
             >
               <Link
                 href={BuyTicketPageLink.online}
@@ -67,8 +70,8 @@ export const BuyTicketSection = () => {
                 rel="noopener noreferrer"
                 className="font-bold flex items-center text-22 [&_svg]:size-6"
               >
-                <span className="text-18 leading-[1.8]">
-                  オンライン参加はこちら
+                <span className="text-18 lg:text-22 leading-[1.8]">
+                  オンライン参加チケット
                 </span>
                 <ArrowRight />
               </Link>
@@ -76,6 +79,6 @@ export const BuyTicketSection = () => {
           </div>
         </div>
       </div>
-    </div>
+    </SectionGradation>
   );
 };

--- a/src/components/BuyTicketSection/index.tsx
+++ b/src/components/BuyTicketSection/index.tsx
@@ -51,7 +51,7 @@ export const BuyTicketSection = () => {
                 rel="noopener noreferrer"
                 className="font-bold flex items-center text-22 [&_svg]:size-6"
               >
-                <span className="text-18 leading-[1.8]">現地参加</span>
+                <span className="text-18 leading-[1.8]">現地参加はこちら</span>
                 <ArrowRight />
               </Link>
             </Button>
@@ -67,7 +67,9 @@ export const BuyTicketSection = () => {
                 rel="noopener noreferrer"
                 className="font-bold flex items-center text-22 [&_svg]:size-6"
               >
-                <span className="text-18 leading-[1.8]">オンライン</span>
+                <span className="text-18 leading-[1.8]">
+                  オンライン参加はこちら
+                </span>
                 <ArrowRight />
               </Link>
             </Button>

--- a/src/components/MissionSection/index.tsx
+++ b/src/components/MissionSection/index.tsx
@@ -1,49 +1,58 @@
 import { Decoration } from "../Decoration";
 import { VenueInformation } from "../VenueInformation";
+import { SectionGradation } from "../ui/sectionGradation";
 
-export function MissionSection() {
+function MissionSessionContent() {
   return (
-    <section
-      style={{
-        background:
-          "linear-gradient(180deg, rgba(133, 196, 255, 0.6) 0%, rgba(202, 230, 255, 0.6) 5.28%, rgba(233, 245, 255, 0.6) 8.92%)",
-      }}
-      className="relative z-10"
-    >
-      <div className="p-6 flex flex-col justify-center md:p-10 lg:max-w-[940px] lg:mx-auto lg:py-16">
-        <h2 className="text-sm text-center md:text-lg">MISSION</h2>
+    <div className="p-6 flex flex-col justify-center md:p-10 lg:max-w-[940px] lg:mx-auto lg:py-16">
+      <h2 className="text-sm text-center md:text-lg">MISSION</h2>
 
-        <p className="text-blue-500 text-xl font-bold text-center mt-1 lg:mt-4 md:text-2xl lg:text-3xl">
-          学び、繋がり、
-          <span className="text-2xl md:text-4xl lg:text-[42px] font-noto">
-            ”型”
-          </span>
-          を破ろう
-        </p>
-        <div className="flex justify-center mt-4 lg:mt-6">
-          <Decoration />
-        </div>
-        <div className="mt-6 text-16 md:text-18 lg:mt-10 leading-[1.8]">
-          <p>
-            2024年に産声をあげ、大盛況のうちに幕を閉じた TSKaigi
-            を今年も開催します！
-          </p>
-          <br />
-          <p>
-            私たちは、誰かの発表を聞くだけでなく、他の誰かに向けて発表することもまた学びの一つだと考えています。
-            参加者、登壇者、スタッフ、スポンサーをはじめ、TSKaigi
-            に関わるすべての人たちが互いに学び合い、新たな繋がりを生み出し、型にとらわれないエンジニアとして生き生きと活躍できる世界を目指します。
-            その実現に向け、今年は会場を中野から神田へ移し、2日間開催とすることで、大幅にパワーアップしました。
-          </p>
-          <br />
-          <p>
-            TypeScript
-            に関するあらゆるテーマを扱う国内最大級のカンファレンスとして、まさに「型破り」なイベントを目指し成長を続ける
-            TSKaigi にご期待ください。
-          </p>
-        </div>
-        <VenueInformation />
+      <p className="text-blue-500 text-xl font-bold text-center mt-1 lg:mt-4 md:text-2xl lg:text-3xl">
+        学び、繋がり、
+        <span className="text-2xl md:text-4xl lg:text-[42px] font-noto">
+          ”型”
+        </span>
+        を破ろう
+      </p>
+      <div className="flex justify-center mt-4 lg:mt-6">
+        <Decoration />
       </div>
+      <div className="mt-6 text-16 md:text-18 lg:mt-10 leading-[1.8]">
+        <p>
+          2024年に産声をあげ、大盛況のうちに幕を閉じた TSKaigi
+          を今年も開催します！
+        </p>
+        <br />
+        <p>
+          私たちは、誰かの発表を聞くだけでなく、他の誰かに向けて発表することもまた学びの一つだと考えています。
+          参加者、登壇者、スタッフ、スポンサーをはじめ、TSKaigi
+          に関わるすべての人たちが互いに学び合い、新たな繋がりを生み出し、型にとらわれないエンジニアとして生き生きと活躍できる世界を目指します。
+          その実現に向け、今年は会場を中野から神田へ移し、2日間開催とすることで、大幅にパワーアップしました。
+        </p>
+        <br />
+        <p>
+          TypeScript
+          に関するあらゆるテーマを扱う国内最大級のカンファレンスとして、まさに「型破り」なイベントを目指し成長を続ける
+          TSKaigi にご期待ください。
+        </p>
+      </div>
+      <VenueInformation />
+    </div>
+  );
+}
+
+export type MissionSectionProps = {
+  isFirstSection: boolean;
+};
+
+export function MissionSection(props: MissionSectionProps) {
+  return props.isFirstSection ? (
+    <SectionGradation>
+      <MissionSessionContent />
+    </SectionGradation>
+  ) : (
+    <section className="bg-blue-light-100">
+      <MissionSessionContent />
     </section>
   );
 }

--- a/src/components/ui/sectionGradation.tsx
+++ b/src/components/ui/sectionGradation.tsx
@@ -1,0 +1,21 @@
+type SectionGradationProps = {
+  children: React.ReactNode;
+  classNames?: string;
+};
+
+export const SectionGradation = ({
+  children,
+  classNames,
+}: SectionGradationProps) => {
+  return (
+    <section
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(133, 196, 255, 0.6) 0%, rgba(202, 230, 255, 0.6) 5.28%, rgba(233, 245, 255, 0.6) 8.92%)",
+      }}
+      className={`relative z-10 ${classNames ? classNames : ""}`}
+    >
+      {children}
+    </section>
+  );
+};


### PR DESCRIPTION
# やったこと

- ホバー時の色を black-100 に変更
- トップページにチケット購入セクションを追加
  - wip でも wipじゃなくても firstSection が固定されたので、isFirstSection の分岐を削除

wip に反映したものを 会場チケットチームに 確認いただいています
https://tskaigi.slack.com/archives/C0601SMHQAK/p1742695360632059?thread_ts=1742354313.754079&cid=C0601SMHQAK

# スクショ

## PC

<img width="996" alt="スクリーンショット 2025-03-23 11 05 45" src="https://github.com/user-attachments/assets/178ccf82-7001-495e-9e18-651fa835874a" />

## tablet


<img width="440" alt="スクリーンショット 2025-03-23 11 06 32" src="https://github.com/user-attachments/assets/0f91a161-f151-4e30-a4e6-2b814d34046d" />

## スマホ

<img width="405" alt="スクリーンショット 2025-03-23 2 34 19" src="https://github.com/user-attachments/assets/edab9f13-4aff-4e70-ae51-ca4104753477" />

<img width="407" alt="スクリーンショット 2025-03-23 11 06 58" src="https://github.com/user-attachments/assets/a2d3bdb6-606f-442d-84c2-7fc71d03abbe" />

