### PR TITLE
[WIP] fix: スポンサーからの修正依頼 - リンクタイトル修正

### DIFF
--- a/src/constants/sponsorList.ts
+++ b/src/constants/sponsorList.ts
@@ -350,11 +350,11 @@ export const sponsorList: SponsorList = {
           href: "https://flatt.tech/assessment",
         },
         {
-          title: "Shisho Cloud - 自動脆弱性診断",
+          title: "Shisho Cloud byGMO - 自動脆弱性診断",
           href: "https://shisho.dev/ja",
         },
         {
-          title: "KENRO - セキュアコーディング研修",
+          title: "KENRO byGMO - セキュアコーディング研修",
           href: "https://flatt.tech/kenro",
         },
       ],


### PR DESCRIPTION
## 概要
GMO Flatt Security株式会社様のスポンサーサービスの名称を修正

## 変更内容
- `src/constants/sponsorList.ts`のスポンサーサービス名を以下のように修正
  - "Shisho Cloud - 自動脆弱性診断" → "Shisho Cloud byGMO - 自動脆弱性診断"
  - "KENRO - セキュアコーディング研修" → "KENRO byGMO - セキュアコーディング研修"

## 影響範囲
- スポンサー一覧ページ
  http://localhost:3001/sponsors
  |PC|SMT|
  |:-:|:-:|
  |<img width="980" alt="スクリーンショット 2025-03-24 14 29 17" src="https://github.com/user-attachments/assets/1de2af02-2256-4b56-8d34-a0cccd3bd8aa" />|<img width="364" alt="スクリーンショット 2025-03-24 14 45 36" src="https://github.com/user-attachments/assets/944c9928-93b9-4066-aa3f-518413c5eefd" />|


- スポンサー詳細ページ
  http://localhost:3001/wip/sponsors/gmo-flatt-security
  |PC|SMT|
  |:-:|:-:|
  |<img width="1500" alt="スクリーンショット 2025-03-24 16 47 57" src="https://github.com/user-attachments/assets/ed23930f-948f-44b8-93c9-b426795b8b24" />|<img width="363" alt="スクリーンショット 2025-03-24 16 48 37" src="https://github.com/user-attachments/assets/1defdeec-3ad7-4047-9aba-8bcded080d78" />|

## チェックリスト
- [x] スポンサー一覧ページで正しく表示されているか
- [x] サービス名の表記が正確か

## 備考
ref: https://tskaigi.slack.com/archives/C062J30MAG6/p1742528294523359
