### PR TITLE
スポンサー詳細ページ 高さ調整

### DIFF
--- a/src/app/sponsors/layout.tsx
+++ b/src/app/sponsors/layout.tsx
@@ -7,10 +7,12 @@ type Props = {
 
 export default function SponsorLayout({ children }: Props) {
   return (
-    <>
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="bg-blue-light-100 pt-16 py-10 md:px-8">{children}</main>
+      <main className="bg-blue-light-100 pt-16 py-10 md:px-8 flex-1">
+        {children}
+      </main>
       <Footer />
-    </>
+    </div>
   );
 }

--- a/src/app/wip/sponsors/layout.tsx
+++ b/src/app/wip/sponsors/layout.tsx
@@ -7,10 +7,12 @@ type Props = {
 
 export default function SponsorLayout({ children }: Props) {
   return (
-    <>
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="bg-blue-light-100 pt-16 py-10 md:px-8">{children}</main>
+      <main className="bg-blue-light-100 pt-16 py-10 md:px-8 flex-1">
+        {children}
+      </main>
       <Footer />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
大きい画面での表示の際に、フッターの下に余白ができないようメインコンテンツのサイズを調整しました。