### PR TITLE
feat: トーク詳細ページの一部を実装

### DIFF
--- a/src/app/talks/[id]/page.tsx
+++ b/src/app/talks/[id]/page.tsx
@@ -1,0 +1,72 @@
+import { talkIds } from "@/constants/talkList";
+import { getTalk } from "@/utils/getTalk";
+
+export async function generateStaticParams() {
+  return talkIds;
+}
+
+export default async function TaklDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const talk = getTalk(id);
+
+  return (
+    <main className="bg-blue-light-100 pt-16 pb-10 md:py-16 md:px-8 lg:px-10">
+      <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
+        トーク
+      </h1>
+
+      <div className="bg-white flex flex-col gap-6 max-w-screen-xl mx-auto md:rounded-xl pb-6 md:pb-8 lg:pb-10">
+        {/* トーク OGP */}
+        <div className="bg-black-100 flex justify-center md:mt-8 md:mx-8 lg:mt-10 lg:mx-10">
+          <img
+            width="730"
+            height="383"
+            className="w-full max-w-[730px] h-auto max-h-[383px] mx-auto object-contain"
+            src={`/ogp/talks/${talk.id}.png`}
+            alt="logo"
+          />
+        </div>
+
+        {/* トーク説明文 */}
+        <div className="px-6 md:px-8 lg:px-10 gap-6 flex flex-col">
+          {talk.overview?.map((overview) => (
+            <p key={overview} className="whitespace-pre-wrap md:text-lg">
+              {overview}
+            </p>
+          ))}
+        </div>
+
+        {/* スピーカー情報 */}
+        {/* FIXME: デザイン未調整 */}
+        {/* <div className="pt-8 p-10">
+          <div className="bg-blue-light-200 p-6 rounded-xl">
+            <div className="flex flex-col md:flex-row items-center gap-4">
+              <div className="w-24 h-24 rounded-full overflow-hidden">
+                <img
+                  src={`/talks/speaker/${talk.id}.jpg`}
+                  alt={talk.speakerName}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div>
+                <p className="font-bold text-lg">{talk.speakerName}</p>
+                <div className="flex gap-2 mt-2">
+                  <a href="#" target="_blank" rel="noopener noreferrer">
+                    <TwitterIcon />
+                  </a>
+                  <a href="#" target="_blank" rel="noopener noreferrer">
+                    <GithubIcon />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div> */}
+      </div>
+    </main>
+  );
+}

--- a/src/app/talks/[id]/page.tsx
+++ b/src/app/talks/[id]/page.tsx
@@ -5,7 +5,7 @@ export async function generateStaticParams() {
   return talkIds;
 }
 
-export default async function TaklDetailPage({
+export default async function TalkDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;

--- a/src/constants/talkList.ts
+++ b/src/constants/talkList.ts
@@ -42,6 +42,7 @@ export type Talk = {
   track: Track;
   talkType: TalkType;
   title: string;
+  overview?: string[];
   speakerName: string;
 };
 
@@ -52,6 +53,11 @@ export const talkList: Talk[] = [
     track: "TRACK2",
     talkType: "SESSION",
     title: "静的解析で実現したいことから逆算して学ぶTypeScript Compiler",
+    overview: [
+      "静的解析には、コードベースから情報を抽出したり、自動的に編集を行ったり、多くの活用方法があります。ESTreeに関連したライブラリをベースに静的解析でなにかを実現することと比べて、TypeScript Compilerを活用することの難易度は高いです。これはプラグインの充実度や関連する資料の量などエコシステムとしての広がりの差に原因があると考えられます。",
+      "難易度が高いTypeScript Compilerですが、プロジェクトの型情報を活用できるだけでなく、提供されるAPIの型が強力であることや依存関係が少なくなることなど、ツールを作るベースとして採用する複数のメリットがあります。",
+      "この発表では、「静的解析で何を実現したいか」を軸にそこから逆算して必要になるTypeScript Compilerの知識を紹介します。TypeScript Compilerを使ってなにかを作るきっかけを提供できることを願っています。",
+    ],
     speakerName: "Kazushi Konosu",
   },
   {
@@ -618,3 +624,7 @@ export const talkList: Talk[] = [
     speakerName: "成原 聡一朗",
   },
 ];
+
+export const talkIds = talkList.map((talk) => ({
+  id: talk.id,
+}));


### PR DESCRIPTION
# 実装内容

- トーク詳細ページの一部デザインを実装

# この PR では対応していないもの

- 登壇者情報の表示
- 各トーク内容のデータ作成

# スクショ

| pc | tablet | sp |
| --- | --- | --- |
|![pc](https://github.com/user-attachments/assets/642e35f1-23b8-4828-a1d0-487843c51bfc)|![tablet](https://github.com/user-attachments/assets/df5c4f54-e367-47ab-98d2-40c999632235)|![sp](https://github.com/user-attachments/assets/08eecac1-5f30-41b2-9507-a511512f7251)|