### PR TITLE
fix: スポンサー表記を「主催」に変更

### DIFF
--- a/src/components/SideEvent/index.tsx
+++ b/src/components/SideEvent/index.tsx
@@ -77,7 +77,7 @@ const SideEvent = ({
               {detail}
             </p>
             <p className="md:text-lg lg:text-base lg:text-right">
-              スポンサー: {sponsors.join("、 ")}
+              主催: {sponsors.join("、 ")}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## やりとり
https://tskaigi.slack.com/archives/C062J30MAG6/p1745578107158489

## キャプチャ
![image](https://github.com/user-attachments/assets/635594b7-db9a-4d70-b399-754a59fd47c6)
