### PR TITLE
fix: 登壇者のアイコンサイズを調整

### DIFF
--- a/src/app/talks/[username]/page.tsx
+++ b/src/app/talks/[username]/page.tsx
@@ -115,7 +115,7 @@ export default async function TalkDetailPage({
           <div className="bg-blue-light-200 p-6 rounded-xl">
             <div className="flex flex-col sm:flex-row items-center gap-6">
               {/* アイコン */}
-              <div className="w-[180px] md:w-[220px] h-auto rounded-full overflow-hidden">
+              <div className="w-[180px] min-w-[180px] md:w-[220px] md:min-w-[220px] h-auto rounded-full overflow-hidden">
                 <img
                   src={`/talks/speaker/${talk.speaker.profileImagePath || "dummy.png"}`}
                   alt={talk.speaker.name}


### PR DESCRIPTION
Tablet 以上のサイズのときにプロフィールの分量が多い場合にアイコンが小さくなってしまっていた

## Before

![screenshot 2025-05-03 20 31 08](https://github.com/user-attachments/assets/adefb227-3ee0-4a4a-ba36-d50ad2b8b99a)

## After

![screenshot 2025-05-03 20 29 34](https://github.com/user-attachments/assets/91dd84af-6fd5-4755-8c71-8bf28a569e40)