### PR TITLE
fix: 登壇者画像が横長の場合に対応

### DIFF
--- a/src/app/talks/[username]/page.tsx
+++ b/src/app/talks/[username]/page.tsx
@@ -116,7 +116,7 @@ export default async function TalkDetailPage({
           <div className="bg-blue-light-200 p-6 rounded-xl">
             <div className="flex flex-col sm:flex-row items-center gap-6">
               {/* アイコン */}
-              <div className="w-[180px] min-w-[180px] md:w-[220px] md:min-w-[220px] h-auto rounded-full overflow-hidden">
+              <div className="w-[180px] md:w-[220px] aspect-square shrink-0 rounded-full overflow-hidden">
                 <img
                   src={`/talks/speaker/${talk.speaker.profileImagePath || "dummy.png"}`}
                   alt={talk.speaker.name}


### PR DESCRIPTION
画像が横長の場合も楕円にならないように修正
もともと意図通り表示されていた画像もそのまま表示される

## Before

![screenshot 2025-05-04 12 48 51](https://github.com/user-attachments/assets/af6c7906-e097-4c07-b5cc-6e97080a0c3e)

## After

![screenshot 2025-05-04 12 46 30](https://github.com/user-attachments/assets/ced3a59e-d426-407e-bccc-7aeff37635eb)
