### PR TITLE
feat: タイムテーブルにて、2日目はDay2タブがデフォルトで開く

### DIFF
--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -12,12 +12,28 @@ import { useState } from "react";
 const TalksPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [currentDate, setCurrentDate] = useState<EventDate>(
-    searchParams.get("day") === "2" ? "DAY2" : "DAY1",
-  );
+
+  const eventDayParam = searchParams.get("day");
+
+  const currentDate = new Date();
+  const isDay2 =
+    currentDate.getFullYear() === 2025 &&
+    currentDate.getMonth() === 4 &&
+    currentDate.getDate() === 24;
+
+  const defaultDay: EventDate = eventDayParam
+    ? eventDayParam === "2"
+      ? "DAY2"
+      : "DAY1"
+    : isDay2
+      ? "DAY2"
+      : "DAY1";
+
+  const [currentEventDate, setCurrentEventDate] =
+    useState<EventDate>(defaultDay);
 
   const handleTabChange = (date: EventDate) => {
-    setCurrentDate(date);
+    setCurrentEventDate(date);
     const day = date === "DAY1" ? "1" : "2";
     const params = new URLSearchParams(searchParams.toString());
     params.set("day", day);
@@ -30,7 +46,10 @@ const TalksPage = () => {
         タイムテーブル
       </h1>
       <div className="text-center mt-8">
-        <EventDateTab currentDate={currentDate} onTabChange={handleTabChange} />
+        <EventDateTab
+          currentDate={currentEventDate}
+          onTabChange={handleTabChange}
+        />
       </div>
 
       <div className="overflow-x-auto mt-10">
@@ -44,7 +63,7 @@ const TalksPage = () => {
             </GridWrapper>
           </div>
 
-          {currentDate === "DAY1" ? <Day1TimeTable /> : <Day2TimeTable />}
+          {currentEventDate === "DAY1" ? <Day1TimeTable /> : <Day2TimeTable />}
         </div>
       </div>
     </main>


### PR DESCRIPTION
# 変更内容

タイムテーブルにて、2日目（2025/05/24）はDay2タブがデフォルトで開くようにしました。

# 開発者確認

- 2025/05/10に以下を確認
  - `http://localhost:3000/talks` にアクセスすると、**Day1**のタイムテーブルが表示されること
  - `http://localhost:3000/talks?day=1` にアクセスすると、Day1のタイムテーブルが表示されること
  - `http://localhost:3000/talks?day=2` にアクセスすると、Day2のタイムテーブルが表示されること
- システム設定にて日付を2025/05/24に変更して以下を確認
  - `http://localhost:3000/talks` にアクセスすると、**Day2**のタイムテーブルが表示されること
  - `http://localhost:3000/talks?day=1` にアクセスすると、Day1のタイムテーブルが表示されること
  - `http://localhost:3000/talks?day=2` にアクセスすると、Day2のタイムテーブルが表示されること