### PR TITLE
タイムテーブルのスタイル修正

### DIFF
--- a/src/components/talks/CommonTrackWrapper/index.tsx
+++ b/src/components/talks/CommonTrackWrapper/index.tsx
@@ -9,7 +9,7 @@ export function CommonTrackWrapper({ timeText, eventText }: Props) {
   return (
     <div className="grid gap-1 mt-4 md:mt-2 grid-cols-[1fr] md:grid-cols-[auto_1fr]">
       <TimeSlot timeText={timeText} />
-      <div className="bg-white p-5 h-16 flex items-center justify-center text-black-700">
+      <div className="bg-gray-50 p-5 h-16 flex items-center justify-center text-black-700">
         {eventText}
       </div>
     </div>

--- a/src/components/talks/LtWrapper/index.tsx
+++ b/src/components/talks/LtWrapper/index.tsx
@@ -22,7 +22,16 @@ export function LtWrapper({ talks }: Props) {
             ) : (
               <p className="text-16">{talk.title}</p>
             )}
-            <p className="text-14">{talk.speaker.name}</p>
+            <div className="flex items-center gap-2">
+              <span className="text-14">{talk.speaker.name}</span>
+              {talk.speaker.profileImagePath && (
+                <img
+                  src={`/talks/speaker/${talk.speaker.profileImagePath}`}
+                  alt={`${talk.speaker.name}のプロフィール画像`}
+                  className="h-6 w-6 rounded-full aspect-square shrink-0 object-cover"
+                />
+              )}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/talks/LtWrapper/index.tsx
+++ b/src/components/talks/LtWrapper/index.tsx
@@ -15,7 +15,7 @@ export function LtWrapper({ talks }: Props) {
             {talk.speaker.username ? (
               <Link
                 href={`/talks/${talk.speaker.username}`}
-                className="hover:underline"
+                className="underline hover:text-blue-purple-500"
               >
                 <p className="text-16">{talk.title}</p>
               </Link>

--- a/src/components/talks/SessionWrapper/index.tsx
+++ b/src/components/talks/SessionWrapper/index.tsx
@@ -13,7 +13,7 @@ export function SessionWrapper({ talk }: Props) {
         {talk.speaker.username ? (
           <Link
             href={`/talks/${talk.speaker.username}`}
-            className="hover:underline"
+            className="underline hover:text-blue-purple-500"
           >
             <p className="text-16">{talk.title}</p>
           </Link>

--- a/src/components/talks/SessionWrapper/index.tsx
+++ b/src/components/talks/SessionWrapper/index.tsx
@@ -20,7 +20,16 @@ export function SessionWrapper({ talk }: Props) {
         ) : (
           <p className="text-16">{talk.title}</p>
         )}
-        <p className="text-14">{talk.speaker.name}</p>
+        <div className="flex items-center gap-2">
+          <span className="text-14">{talk.speaker.name}</span>
+          {talk.speaker.profileImagePath && (
+            <img
+              src={`/talks/speaker/${talk.speaker.profileImagePath}`}
+              alt={`${talk.speaker.name}のプロフィール画像`}
+              className="h-6 w-6 rounded-full aspect-square shrink-0 object-cover"
+            />
+          )}
+        </div>
       </div>
     </EventWrapper>
   );


### PR DESCRIPTION
## 対応したこと

- 休憩のセクションの背景色をグレーに
- トーク一覧に登壇者の画像追加
- トークタイトルをホバーした時のスタイル追加

## キャプチャ

![localhost_3000_talks_day=2 (1)](https://github.com/user-attachments/assets/c23cf276-8d9f-49e2-b2af-31eb935ed219)

## 関連するissue

- close #291
- close #293 

## 備考

- LTのラベルは別で対応します
- リンクをホバーした時はテキストの色が青になるようにしています
- https://tskaigi.slack.com/archives/C062J30MAG6/p1746848162142519
