### PR TITLE
feat: 緊急のお知らせ枠の修正

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -33,10 +33,6 @@ const links: {
     href: "/code-of-conduct",
     label: "行動規範",
   },
-  {
-    href: "/", // TODO: リンクが確定したら修正する
-    label: "お問い合わせ",
-  },
 ];
 
 export function Header() {

--- a/src/components/OnTheDaySection/Notes/Caution/index.tsx
+++ b/src/components/OnTheDaySection/Notes/Caution/index.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export function Caution({ children }: Props) {
   return (
-    <p className="flex gap-3 items-start" role="alert">
+    <p className="flex gap-3 items-start">
       <span className="text-blue-500" aria-hidden="true">
         －
       </span>

--- a/src/components/OnTheDaySection/UrgentAnnouncement/index.tsx
+++ b/src/components/OnTheDaySection/UrgentAnnouncement/index.tsx
@@ -5,7 +5,14 @@ import { LinkText } from "@/components/OnTheDaySection/Notes/LinkText";
  * @description
  * 緊急のお知らせを表示するコンポーネント。緊急時以外は表示しない。
  */
-export function UrgentAnnouncement() {
+export function UrgentAnnouncement({
+  isVisible,
+}: {
+  /**コンポーネントを表示するかどうか */
+  isVisible: boolean;
+}) {
+  if (!isVisible) return null;
+
   return (
     <section
       className="bg-white w-full flex flex-col gap-3 justify-center rounded-lg md:rounded-2xl px-6 py-5 md:px-8 md:py-6"

--- a/src/components/OnTheDaySection/UrgentAnnouncement/index.tsx
+++ b/src/components/OnTheDaySection/UrgentAnnouncement/index.tsx
@@ -7,7 +7,14 @@ import { LinkText } from "@/components/OnTheDaySection/Notes/LinkText";
  */
 export function UrgentAnnouncement() {
   return (
-    <div className="bg-white w-full flex flex-col gap-3 justify-center rounded-lg md:rounded-2xl px-6 py-5 md:px-8 md:py-6">
+    <section
+      className="bg-white w-full flex flex-col gap-3 justify-center rounded-lg md:rounded-2xl px-6 py-5 md:px-8 md:py-6"
+      role="alert"
+      aria-labelledby="alert_description"
+    >
+      <span id="alert_description" className="sr-only">
+        緊急のお知らせ
+      </span>
       <Caution>
         ダミーの緊急のお知らせです。詳細は
         <LinkText href="https://example.com" target="_blank">
@@ -21,6 +28,6 @@ export function UrgentAnnouncement() {
           ダミーの緊急のお知らせです。
         </LinkText>
       </Caution>
-    </div>
+    </section>
   );
 }

--- a/src/components/OnTheDaySection/index.tsx
+++ b/src/components/OnTheDaySection/index.tsx
@@ -12,8 +12,8 @@ export function OnTheDaySection() {
           </h2>
           <Decoration />
         </div>
-        {/* MEMO: 緊急のお知らせを掲載する場合のみコメントアウトを解除する */}
-        {/* <UrgentAnnouncement /> */}
+        {/* MEMO: 緊急のお知らせを掲載する場合のみ、isVisibleをtrueにする */}
+        <UrgentAnnouncement isVisible={false} />
         <div className="mb-8 mt-8 md:mt-10 flex flex-col items-center justify-center">
           <DecorationButton />
         </div>

--- a/src/components/OnTheDaySection/index.tsx
+++ b/src/components/OnTheDaySection/index.tsx
@@ -1,7 +1,6 @@
 import { Decoration } from "@/components/Decoration";
 import { SectionGradation } from "@/components/ui/sectionGradation";
 import { DecorationButton } from "./DecorationButton";
-import { UrgentAnnouncement } from "./UrgentAnnouncement";
 
 export function OnTheDaySection() {
   return (

--- a/src/components/OnTheDaySection/index.tsx
+++ b/src/components/OnTheDaySection/index.tsx
@@ -1,6 +1,7 @@
 import { Decoration } from "@/components/Decoration";
 import { SectionGradation } from "@/components/ui/sectionGradation";
 import { DecorationButton } from "./DecorationButton";
+import { UrgentAnnouncement } from "./UrgentAnnouncement";
 
 export function OnTheDaySection() {
   return (

--- a/src/components/OnTheDaySection/index.tsx
+++ b/src/components/OnTheDaySection/index.tsx
@@ -6,7 +6,7 @@ import { UrgentAnnouncement } from "./UrgentAnnouncement";
 export function OnTheDaySection() {
   return (
     <SectionGradation>
-      <div className="p-6 flex flex-col justify-center lg:max-w-[940px] lg:mx-auto lg:py-16">
+      <div className="mx-6 flex flex-col justify-center lg:max-w-[940px] lg:mx-auto pt-6 lg:pt-16 max-sm:pb-2">
         <div className="flex flex-col items-center self-stretch mb-10">
           <h2 className="lg:text-[32px] md:text-[28px] text-[24px] font-bold text-center pb-4">
             当日のお知らせ

--- a/src/components/OnTheDaySection/index.tsx
+++ b/src/components/OnTheDaySection/index.tsx
@@ -13,7 +13,8 @@ export function OnTheDaySection() {
           </h2>
           <Decoration />
         </div>
-        <UrgentAnnouncement />
+        {/* MEMO: 緊急のお知らせを掲載する場合のみコメントアウトを解除する */}
+        {/* <UrgentAnnouncement /> */}
         <div className="mb-8 mt-8 md:mt-10 flex flex-col items-center justify-center">
           <DecorationButton />
         </div>


### PR DESCRIPTION
以下の内容を対応しました。

- ヘッダーのお問い合わせ導線を削除（不要になったため）
- 緊急のお知らせ枠をアクセシブルに変更
- 緊急のお知らせ枠をコメントアウト