### PR TITLE
fix: 現在時刻のタイムスロットだけUIを変える件の改善

### DIFF
--- a/src/hooks/useTimetable.ts
+++ b/src/hooks/useTimetable.ts
@@ -91,14 +91,20 @@ export const useTimetable = ({
   const [currentTime, setCurrentTime] = useState<Date>(new Date());
 
   useEffect(() => {
-    if (!isConferencePeriod()) return;
+    const now = new Date();
+    const isConferenceDay =
+      now.getFullYear() === 2025 &&
+      now.getMonth() === 4 &&
+      (now.getDate() === 23 || now.getDate() === 24);
+    if (!isConferenceDay) return;
+
     setCurrentTime(new Date());
     const interval = setInterval(() => {
       setCurrentTime(new Date());
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [isConferencePeriod]);
+  }, []);
 
   const isSessionActive = (sessionId: string) => {
     const currentId = getCurrentSessionId(currentTime);


### PR DESCRIPTION
# 概要

タイムテーブルの最初の枠の前にページにアクセス済みの場合、リロードしないと現在時刻用のタイムスロットUIにならない。
5/23か5/24にアクセスしていればリロードしなくても現在時刻用のタイムスロットUIとなるように修正。

# 確認動画

https://github.com/user-attachments/assets/41337562-41e3-40b4-98b1-46a5b577f9cc