### PR TITLE
トーク詳細ページにトーク情報の文字情報を追加

### DIFF
--- a/src/app/talks/[username]/page.tsx
+++ b/src/app/talks/[username]/page.tsx
@@ -1,4 +1,4 @@
-import { usernames } from "@/constants/talkList";
+import { TALK_TYPE, TRACK, usernames } from "@/constants/talkList";
 import { getTalk } from "@/utils/getTalk";
 import { shouldDisplaySpeakerInfo } from "@/utils/shouldDisplaySpeakerInfo";
 import type { Metadata } from "next";
@@ -103,6 +103,14 @@ export default async function TalkDetailPage({
             src={`/ogp/talks/${talk.speaker.username}.png`}
             alt={talk.title}
           />
+        </div>
+
+        <div className="px-6 md:px-8 lg:px-10 flex flex-col gap-1">
+          <div className="text-lg">{TALK_TYPE[talk.talkType].name}</div>
+          <div className="text-2xl font-bold">{talk.title}</div>
+          <div className="text-lg font-bold">
+            {talk.eventDate} / {talk.time} （{TRACK[talk.track].name}）
+          </div>
         </div>
 
         {/* トーク説明文 */}


### PR DESCRIPTION
# 方針

とりあえずデザインはよしなで、暫定対応を優先しています

# セルフチェック事項

- [x] タイトルが長いトークでも違和感がないこと
- [x] 招待講演・主催者講演・OSTなどの特殊なトークでも違和感がないこと
- [x] スマホ・モバイル・PC各デバイスで問題ないこと

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/29d7f246-b753-401e-821f-2fd828dcf9ad" />


<img width="775" alt="image" src="https://github.com/user-attachments/assets/bf2c101e-ffe3-4f71-8e24-93b5d34bd299" />


<img width="493" alt="image" src="https://github.com/user-attachments/assets/9e2945d1-dfb9-43d8-830c-1f0588015a3f" />
